### PR TITLE
Fix "plugin was built with a different version of package internal/goarch" for golangci-lint v1.56.2 and others

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,4 @@ go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint."

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-output=$(go version -m echo $(which golangci-lint))
+output=$(go version -m $(which golangci-lint))
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
@@ -13,4 +13,4 @@ go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
 go mod tidy
 
 echo building nilaway.so with GOARCH=$GOARCH GOOS=$GOOS tools_version=$tools_version go_version=$go_version ...
-GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -o nilaway.so ./plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file."
+GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file."


### PR DESCRIPTION
## Summary

I was unable to build the nilaway plugin that works with my version of golangci-lint using `local_build.sh`.

After investigating, I found the cause is that the `-trimpath` option was missing from the line with `go build`.

## Steps to reproduce

```
$ git checkout main

$ go version
go version go1.22.0 darwin/arm64

$ golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a on 2024-02-15T12:52:06Z

$ ./local_build.sh
stat echo: no such file or directory
0.18.0
go: creating new go.mod: module github.com/nilaway-plugin
go: to add module requirements and sums:
        go mod tidy
go: finding module for package golang.org/x/tools/go/analysis
go: finding module for package go.uber.org/nilaway
go: found go.uber.org/nilaway in go.uber.org/nilaway v0.0.0-20240224031343-67945fb5199f
go: found golang.org/x/tools/go/analysis in golang.org/x/tools v0.18.0
building nilaway.so with GOARCH=arm64 GOOS=darwin tools_version=0.18.0 go_version=1.22.0 ...
nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file.

$ mv nilaway.so "$MY_PROJECT/src/nilaway.so" && cd "$MY_PROJECT/src"

$ golangci-lint version
ERRO Unable to load custom analyzer nilaway:./src/nilaway.so, plugin.Open("/Users/taimoorahmad/repos/cli/src/nilaway"): plugin was built with a different version of package internal/goarch 
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a on 2024-02-15T12:52:06Z

```

# Root Cause/Fix

```
$ go version -m $(which golangci-lint)
/opt/homebrew/bin/golangci-lint: go1.22.0
	path	github.com/golangci/golangci-lint/cmd/golangci-lint
	mod	github.com/golangci/golangci-lint	(devel)
            <removed lines about dep - not relevant>
	build	-buildmode=exe
	build	-compiler=gc
	build	-trimpath=true
	build	DefaultGODEBUG=httplaxcontentlength=1,httpmuxgo121=1,tls10server=1,tlsrsakex=1,tlsunsafeekm=1
	build	CGO_ENABLED=1
	build	GOARCH=arm64
	build	GOOS=darwin
	build	vcs=git
	build	vcs.revision=58a724a05e33a040826b471b2e6a8a8fc970feb2
	build	vcs.time=2024-02-15T12:52:06Z
	build	vcs.modified=true

```

From the output, I noticed some `build` options were different. `buildmode` and `compiler` and `vcs` are not relevant. Also, setting `CGO_ENABLED=1` did not help. 

Once I set `-trimpath`, I was able to build a compatible version.

```
$ GOARCH="arm64" GOOS="darwin" go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go

$ mv nilaway.so "$MY_PROJECT/src/nilaway.so" && cd "$MY_PROJECT/src"

$ golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a on 2024-02-15T12:52:06Z

# from here, golangci-lint runs successfully!
```