### PR TITLE
Refact: typos and shell improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 
 # Go workspace file
 go.work
+
+# exclude go files that will be generated during build
+go.mod
+go.sum

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nilaway-plugin
 
-nilaway, as its current form, still reports a fair number of false positives. This makes nilaway fail to be merged with golangci-lint and be offered as a linter (see [PR#4045](https://github.com/golangci/golangci-lint/issues/4045)). 
+NilAway, as its current form, still reports a fair number of false positives. This makes NilAway fail to be merged with golangci-lint and be offered as a linter (see [PR#4045](https://github.com/golangci/golangci-lint/issues/4045)). 
 
 It's a custom build plugin to add [nilaway](https://github.com/uber-go/nilaway) to golangci-lint.
 
@@ -61,4 +61,4 @@ custom:
 
 ## Useful links  
 - for more info about plugins [configuration](https://golangci-lint.run/contributing/new-linters/#configure-a-plugin).
-- for nilaway [configuration](https://github.com/uber-go/nilaway/wiki/Configuration)
+- for NilAway [configuration](https://github.com/uber-go/nilaway/wiki/Configuration)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nilaway-plugin
 
-NilAway, as its current form, still reports a fair number of false positives. This makes NilAway fail to be merged with golangci-lint and be offered as a linter (see [PR#4045](https://github.com/golangci/golangci-lint/issues/4045)). 
+nilaway, as its current form, still reports a fair number of false positives. This makes nilaway fail to be merged with golangci-lint and be offered as a linter (see [PR#4045](https://github.com/golangci/golangci-lint/issues/4045)). 
 
-It's a custom build plugin to add [nilway](https://github.com/uber-go/nilaway) to golangci-lint.
+It's a custom build plugin to add [nilaway](https://github.com/uber-go/nilaway) to golangci-lint.
 
 ## Usage
 the scripts will automatically detect the go version, OS and ARCH. 
@@ -28,7 +28,7 @@ Because building plugins need the dependency versions between the plugin and lin
            pretty-print: true
            exclude-pkgs: "pkgA,pkgB"
 
-### Github actions
+### GitHub actions
 
 add this step in your gha workflow file, before the usage of golangci-lint
 
@@ -61,4 +61,4 @@ custom:
 
 ## Useful links  
 - for more info about plugins [configuration](https://golangci-lint.run/contributing/new-linters/#configure-a-plugin).
-- for NilAway [configuration](https://github.com/uber-go/nilaway/wiki/Configuration)
+- for nilaway [configuration](https://github.com/uber-go/nilaway/wiki/Configuration)

--- a/build.sh
+++ b/build.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 
-echo "$1"
+set -euo pipefail
+
+YELLOW=$'\e[0;33m'
+NC=$'\e[0m'
+
+[[ -z "${1:-}" ]] && echo "usage: $0 (v1.X.X|latest)" && exit 1
+
 gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
 output=$(cat "$gomod")
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-if [[ "$local_go_version" != "$go_version" ]]; then
-  echo -e "FYI - the go version being used right now ($local_go_version) is not the same" \
-      "as the one from the go.mod file for golangci-lint ($go_version)"
-    echo -e "continuing the build like normal ..."
-fi
+[[ "$local_go_version" != "$go_version" ]] && \
+  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}" &&
+  echo -e "${YELLOW}continuing build like normal ...${NC}"
 
 go mod init github.com/nilaway-plugin
 go mod tidy

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-echo $1
-gomod=$(go list -m -json github.com/golangci/golangci-lint@$1 | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
-output=$(cat $gomod)
+echo "$1"
+gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
+output=$(cat "$gomod")
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
 go mod init github.com/nilaway-plugin
 go mod tidy
-go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
+go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatible with local golangci-lint."

--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,19 @@ echo "$1"
 gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
 output=$(cat "$gomod")
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
+
+local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [[ "$local_go_version" != "$go_version" ]]; then
+  echo -e "FYI - the go version being used right now ($local_go_version) is not the same" \
+      "as the one from the go.mod file for golangci-lint ($go_version)"
+    echo -e "continuing the build like normal ..."
+fi
 
 go mod init github.com/nilaway-plugin
 go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatible with local golangci-lint."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && \
+  echo -e "nilaway.so is built compatible with golangci-lint $1."

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 YELLOW=$'\e[0;33m'
 NC=$'\e[0m'
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"
+
+[[ -z "${GITHUB_WORKSPACE:-}" ]] && echo "\$GITHUB_WORKSPACE is not set." && exit 1
+
 [[ -z "${1:-}" ]] && echo "usage: $0 (v1.X.X|latest)" && exit 1
 
 gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
@@ -13,14 +18,17 @@ tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[
 go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-[[ "$local_go_version" != "$go_version" ]] && \
-  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}" &&
-  echo -e "${YELLOW}continuing build like normal ...${NC}"
+if [[ "$local_go_version" != "$go_version" ]]; then
+  echo "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}"
+  echo "continuing build like normal ..."
+fi
+
+[[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*
 
 go mod init github.com/nilaway-plugin
 go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && \
-  echo -e "nilaway.so is built compatible with golangci-lint $1."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go
+echo "nilaway.so is built compatible with golangci-lint@$1."

--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,4 @@ go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint."

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -euo pipefail
+
+YELLOW=$'\e[0;33m'
+NC=$'\e[0m'
+
 output=$(go version -m "$(which golangci-lint)")
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
@@ -7,11 +12,9 @@ tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[
 go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-if [[ "$local_go_version" != "$go_version" ]]; then
-  echo -e "FYI - the go version being used right now ($local_go_version) is not the same" \
-    "as the one that was used to build your golangci-lint ($go_version)"
-  echo -e "continuing the build like normal ..."
-fi
+[[ "$local_go_version" != "$go_version" ]] && \
+  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}" &&
+  echo -e "${YELLOW}continuing build like normal ...${NC}"
 
 echo "$tools_version"
 go mod init github.com/nilaway-plugin

--- a/local_build.sh
+++ b/local_build.sh
@@ -6,13 +6,20 @@ GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
+local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [[ "$local_go_version" != "$go_version" ]]; then
+  echo -e "FYI - the go version being used right now ($local_go_version) is not the same" \
+    "as the one that was used to build your golangci-lint ($go_version)"
+  echo -e "continuing the build like normal ..."
+fi
+
 echo "$tools_version"
 go mod init github.com/nilaway-plugin
 go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-echo building nilaway.so with GOARCH="$GOARCH" GOOS="$GOOS" tools_version="$tools_version" go_version="$go_version" ...
+echo building nilaway.so with GOARCH="$GOARCH" GOOS="$GOOS" tools_version="$tools_version" local_go_version="$local_go_version" ...
 GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && \
   echo -e "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
     "and make sure to copy the custom settings to your .golangci.yml file."

--- a/local_build.sh
+++ b/local_build.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 YELLOW=$'\e[0;33m'
 NC=$'\e[0m'
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"
+
 output=$(go version -m "$(which golangci-lint)")
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
@@ -12,17 +15,21 @@ tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[
 go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-[[ "$local_go_version" != "$go_version" ]] && \
-  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}" &&
-  echo -e "${YELLOW}continuing build like normal ...${NC}"
+if [[ "$local_go_version" != "$go_version" ]]; then
+  echo "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}"
+  echo "continuing build like normal ..."
+fi
 
-echo "$tools_version"
+[[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*
+
+set -x
 go mod init github.com/nilaway-plugin
 go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-echo building nilaway.so with GOARCH="$GOARCH" GOOS="$GOOS" tools_version="$tools_version" local_go_version="$local_go_version" ...
-GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && \
-  echo -e "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
-    "and make sure to copy the custom settings to your .golangci.yml file."
+GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go
+set +x
+
+echo "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
+  "and make sure to copy the custom settings to your .golangci.yml file."

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
-output=$(go version -m $(which golangci-lint))
+output=$(go version -m "$(which golangci-lint)")
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
-echo $tools_version
+echo "$tools_version"
 go mod init github.com/nilaway-plugin
 go mod tidy
-go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
+go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-echo building nilaway.so with GOARCH=$GOARCH GOOS=$GOOS tools_version=$tools_version go_version=$go_version ...
-GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file."
+echo building nilaway.so with GOARCH="$GOARCH" GOOS="$GOOS" tools_version="$tools_version" go_version="$go_version" ...
+GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && \
+  echo -e "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
+    "and make sure to copy the custom settings to your .golangci.yml file."

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-output=$(go version -m echo $(which golangci-lint))
+output=$(go version -m $(which golangci-lint))
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
@@ -13,4 +13,4 @@ go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
 go mod tidy
 
 echo building nilaway.so with GOARCH=$GOARCH GOOS=$GOOS tools_version=$tools_version go_version=$go_version ...
-GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -o nilaway.so ./plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file."
+GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file."


### PR DESCRIPTION
PR is based on: https://github.com/moogacs/nilaway-plugin/pull/1 and so it includes changes from that PR. 

* [Fix shellcheck warnings and errors](https://www.shellcheck.net/) from build.sh, build-local.sh
  * These edits are just quoting variables
  * Fixed a few lines that were too long to read
  * Also add `set -euo pipefail` so the build can end faster if something went wrong
  * Add `usage` that gets printed out reminding user they need to pass the version as an arg to ./build
* Fix some typos and ~~capitalization~~
* Fix line that outputs go version - that go version being printed out is the one that was used to build golangci-lint, not the one being used to build the plugin, which is confusing. 
  * It's good to know if I am building using Go 1.21 but my golangci-lint was actually built with Go 1.22. it might not matter but is useful for the user to know about the mismatch.
  * Added the color yellow to make this more visible. 