### PR TITLE
Refact: combine build.sh and build_local.sh into one script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 
 # Go workspace file
 go.work
+
+# exclude go files that will be generated during build
+go.mod
+go.sum

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ add this step in your gha workflow file, before the usage of golangci-lint
         git clone https://github.com/moogacs/nilaway-plugin.git
         cd nilaway-plugin
         chmod +x build.sh
-        ./build.sh v{used golangci-lint version} 
-        # for example ./build v1.54
-        #          or ./build latest
+        ./build.sh v1.X.X # or use 'latest' or 'local'
+        # the compiled .so file will be in $GITHUB_WORKSPACE/.plugins OR
+        # the current directory.
 ```
 
 add the plugin configuration to your `golangci.yaml` file, just like in the [previous section](#locally).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nilaway-plugin
 
-nilaway, as its current form, still reports a fair number of false positives. This makes nilaway fail to be merged with golangci-lint and be offered as a linter (see [PR#4045](https://github.com/golangci/golangci-lint/issues/4045)). 
+NilAway, as its current form, still reports a fair number of false positives. This makes NilAway fail to be merged with golangci-lint and be offered as a linter (see [PR#4045](https://github.com/golangci/golangci-lint/issues/4045)). 
 
 It's a custom build plugin to add [nilaway](https://github.com/uber-go/nilaway) to golangci-lint.
 
@@ -61,4 +61,4 @@ custom:
 
 ## Useful links  
 - for more info about plugins [configuration](https://golangci-lint.run/contributing/new-linters/#configure-a-plugin).
-- for nilaway [configuration](https://github.com/uber-go/nilaway/wiki/Configuration)
+- for NilAway [configuration](https://github.com/uber-go/nilaway/wiki/Configuration)

--- a/README.md
+++ b/README.md
@@ -5,18 +5,34 @@ NilAway, as its current form, still reports a fair number of false positives. Th
 It's a custom build plugin to add [nilaway](https://github.com/uber-go/nilaway) to golangci-lint.
 
 ## Usage
-the scripts will automatically detect the go version, OS and ARCH. 
+
+### Build
+
+The build script lets you do 2 things:
+
+1. Build the nilaway plugin based on the golangci-lint version in your PATH.
+This could be a binary you compiled yourself (recommended) or a binary you downloaded from brew or some other place.
+2. Build the plugin based on a specific version of golangci-lint OR the latest version.
+
+```bash
+./build local                # use what's in $PATH    - get info about the binary using 'go version'
+./build (v1.X.X|latest)      # use a specific version - get info from the go.mod using 'go list'
+```
+
+The build scripts will automatically detect the go version, GOARCH and GOOS.
+If you don't the build script to overwrite those variables, you can `export` them beforehand, or set them in your CI pipeline.
+
 Because building plugins need the dependency versions between the plugin and linter to be consistent, the script detects that automatically.
 
-
 ### Locally
+
 - clone the repo.
-- run `./local_build.sh` 
+- run `./build.sh local`
 - copy the produced `nilaway.so` file to your project dir.
 - add the custom plugin config under `linters-settings`
     ```yaml
     custom:
-    nilaway:
+      nilaway:
         path: ./nilaway.so
         # The description of the linter.
         # Optional.
@@ -25,10 +41,10 @@ Because building plugins need the dependency versions between the plugin and lin
         # Optional.
         original-url: github.com/moogacs/nilaway-plugin
         settings: # Settings are optional.
-           pretty-print: true
-           exclude-pkgs: "pkgA,pkgB"
+          pretty-print: true
+          exclude-pkgs: "pkgA,pkgB"
 
-### GitHub actions
+### GitHub Actions
 
 add this step in your gha workflow file, before the usage of golangci-lint
 
@@ -40,24 +56,10 @@ add this step in your gha workflow file, before the usage of golangci-lint
         chmod +x build.sh
         ./build.sh v{used golangci-lint version} 
         # for example ./build v1.54
+        #          or ./build latest
 ```
 
-add the plugin configuration to your `golangci.yaml` file
-
-```yaml
-custom:
-    nilaway:
-      path: .plugins/nilaway.so
-      # The description of the linter.
-      # Optional.
-       description: This is a custom nilaway plugin linter.
-      # Intended to point to the repo location of the linter.
-      # Optional.
-      original-url: github.com/moogacs/nilaway-plugin
-      settings: # Settings are optional.
-        pretty-print: true
-        exclude-pkgs: "pkgA,pkgB"
-```
+add the plugin configuration to your `golangci.yaml` file, just like in the [previous section](#locally).
 
 ## Useful links  
 - for more info about plugins [configuration](https://golangci-lint.run/contributing/new-linters/#configure-a-plugin).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nilaway-plugin
 
-NilAway, as its current form, still reports a fair number of false positives. This makes NilAway fail to be merged with golangci-lint and be offered as a linter (see [PR#4045](https://github.com/golangci/golangci-lint/issues/4045)). 
+nilaway, as its current form, still reports a fair number of false positives. This makes nilaway fail to be merged with golangci-lint and be offered as a linter (see [PR#4045](https://github.com/golangci/golangci-lint/issues/4045)). 
 
-It's a custom build plugin to add [nilway](https://github.com/uber-go/nilaway) to golangci-lint.
+It's a custom build plugin to add [nilaway](https://github.com/uber-go/nilaway) to golangci-lint.
 
 ## Usage
 the scripts will automatically detect the go version, OS and ARCH. 
@@ -28,7 +28,7 @@ Because building plugins need the dependency versions between the plugin and lin
            pretty-print: true
            exclude-pkgs: "pkgA,pkgB"
 
-### Github actions
+### GitHub actions
 
 add this step in your gha workflow file, before the usage of golangci-lint
 
@@ -61,4 +61,4 @@ custom:
 
 ## Useful links  
 - for more info about plugins [configuration](https://golangci-lint.run/contributing/new-linters/#configure-a-plugin).
-- for NilAway [configuration](https://github.com/uber-go/nilaway/wiki/Configuration)
+- for nilaway [configuration](https://github.com/uber-go/nilaway/wiki/Configuration)

--- a/build.sh
+++ b/build.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 
-echo "$1"
+set -euo pipefail
+
+YELLOW=$'\e[0;33m'
+NC=$'\e[0m'
+
+[[ -z "${1:-}" ]] && echo "usage: $0 (v1.X.X|latest)" && exit 1
+
 gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
 output=$(cat "$gomod")
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-if [[ "$local_go_version" != "$go_version" ]]; then
-  echo -e "FYI - the go version being used right now ($local_go_version) is not the same" \
-      "as the one from the go.mod file for golangci-lint ($go_version)"
-    echo -e "continuing the build like normal ..."
-fi
+[[ "$local_go_version" != "$go_version" ]] && \
+  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}" &&
+  echo -e "${YELLOW}continuing build like normal ...${NC}"
 
 go mod init github.com/nilaway-plugin
 go mod tidy

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-echo $1
-gomod=$(go list -m -json github.com/golangci/golangci-lint@$1 | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
-output=$(cat $gomod)
+echo "$1"
+gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
+output=$(cat "$gomod")
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
 go mod init github.com/nilaway-plugin
 go mod tidy
-go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
+go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatible with local golangci-lint."

--- a/build.sh
+++ b/build.sh
@@ -2,33 +2,87 @@
 
 set -euo pipefail
 
+CYAN=$'\e[0;36m'
+GREEN=$'\e[0;32m'
 YELLOW=$'\e[0;33m'
 NC=$'\e[0m'
 
+# script-wide vars
+build_out="nilaway.so"
+slug=""
+
+[[ -n "${GITHUB_WORKSPACE:-}" ]] && build_out="$GITHUB_WORKSPACE/.plugins/nilaway.so"
+
+# set directory, parse CLI args
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"
 
-[[ -z "${GITHUB_WORKSPACE:-}" ]] && echo "\$GITHUB_WORKSPACE is not set." && exit 1
+usage() {
+  echo "usage: $0 VERSION"
+  echo
+  echo "examples:"
+  echo "  on your local machine/to build for the golangci-lint in your \$PATH:"
+  echo "    $0 local"
+  echo
+  echo "  in ci/to build for a specific golangci-lint version or latest:"
+  echo "    $0 (v1.X.X|latest)"
+  echo
+  echo "  if \$GITHUB_WORKSPACE is set, the .so files will be output in \$GITHUB_WORKSPACE/.plugins/"
+  echo "    otherwise, they will be output in $SCRIPT_DIR/"
+  exit 1
+}
 
-[[ -z "${1:-}" ]] && echo "usage: $0 (v1.X.X|latest)" && exit 1
+case "${1:-}" in
+  local)
+    slug="$(which golangci-lint)"
+    ;;
+  latest|v[0-9]*)
+    slug="golangci-lint@$1"
+    ;;
+  *)
+    usage
+    ;;
+esac
+echo "${CYAN}building nilaway plugin to be compatible with: ${slug}${NC}"
 
-gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
-output=$(cat "$gomod")
-tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
+# gather info about golangci-lint version the plugin is being built for
+# set: tools_version, go_version
+# also set: GOARCH, GOOS -- only if they are not set already.
+if [[ "$1" == "local" ]]; then
+  output=$(go version -m "$(which golangci-lint)")
+  tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
-local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-if [[ "$local_go_version" != "$go_version" ]]; then
-  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}"
-  echo -e "continuing build like normal ..."
+  # go version should provide info about GOARCH/GOOS, set it
+  [[ -z "${GOARCH:-}" ]] && GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2) && echo "${YELLOW}\$GOARCH was empty, now set to ${GOARCH}${NC}"
+  [[ -z "${GOOS:-}" ]] && GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2) && echo "${YELLOW}\$GOOS was empty, now set to ${GOOS}${NC}"
+else
+  gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
+  output=$(cat "$gomod")
+  tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
+
+  # go.mod does not give any GOARCH/GOOS info, so just use what is in go env
+  [[ -z "${GOARCH:-}" ]] && GOARCH=$(go env | grep GOARCH | sed s/\'//g | cut -d '=' -f 2) && echo "${YELLOW}\$GOARCH was empty, now set to ${GOARCH}${NC}"
+  [[ -z "${GOOS:-}" ]] && GOOS=$(go env | grep GOOS | sed s/\'//g | cut -d '=' -f 2) && echo "${YELLOW}\$GOOS was empty, now set to ${GOOS}${NC}"
 fi
 
-[[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*
+# different go versions could potentially cause a problem, inform user
+local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [[ "$local_go_version" != "$go_version 1" ]]; then
+  echo "${YELLOW}warning: local go version ($local_go_version) != go version for $slug ($go_version), this could potentially cause problems${NC}"
+  echo "continuing build like normal ..."
+fi
 
+# perform build
+[[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*
+set -x
 go mod init github.com/nilaway-plugin
-go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go
-echo "nilaway.so is built compatible with golangci-lint@$1."
+GOARCH=$GOARCH GOOS=$GOOS go build -o "$build_out"  -buildmode=plugin -trimpath plugin/nilaway.go
+
+set +x
+echo "${GREEN}nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
+  "and make sure to copy the custom settings to your .golangci.yml file.${NC}"

--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,8 @@ go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 if [[ "$local_go_version" != "$go_version" ]]; then
-  echo "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}"
-  echo "continuing build like normal ..."
+  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}"
+  echo -e "continuing build like normal ..."
 fi
 
 [[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*

--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,19 @@ echo "$1"
 gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
 output=$(cat "$gomod")
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
+
+local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [[ "$local_go_version" != "$go_version" ]]; then
+  echo -e "FYI - the go version being used right now ($local_go_version) is not the same" \
+      "as the one from the go.mod file for golangci-lint ($go_version)"
+    echo -e "continuing the build like normal ..."
+fi
 
 go mod init github.com/nilaway-plugin
 go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatible with local golangci-lint."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && \
+  echo -e "nilaway.so is built compatible with golangci-lint $1."

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 YELLOW=$'\e[0;33m'
 NC=$'\e[0m'
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"
+
+[[ -z "${GITHUB_WORKSPACE:-}" ]] && echo "\$GITHUB_WORKSPACE is not set." && exit 1
+
 [[ -z "${1:-}" ]] && echo "usage: $0 (v1.X.X|latest)" && exit 1
 
 gomod=$(go list -m -json github.com/golangci/golangci-lint@"$1" | grep -o '"GoMod": "[^"]*' | grep -o '[^"]*$')
@@ -13,14 +18,17 @@ tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[
 go_version=$(grep -oE '^go [0-9]+\.[0-9].+' <<< "$output" | cut -d ' ' -f2)
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-[[ "$local_go_version" != "$go_version" ]] && \
-  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}" &&
-  echo -e "${YELLOW}continuing build like normal ...${NC}"
+if [[ "$local_go_version" != "$go_version" ]]; then
+  echo "${YELLOW}warning: local go version ($local_go_version) != go version in go.mod from golangci-lint@$1  ($go_version)${NC}"
+  echo "continuing build like normal ..."
+fi
+
+[[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*
 
 go mod init github.com/nilaway-plugin
 go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && \
-  echo -e "nilaway.so is built compatible with golangci-lint $1."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go
+echo "nilaway.so is built compatible with golangci-lint@$1."

--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,4 @@ go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
 go mod tidy
 
-go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint."
+go build -o "$GITHUB_WORKSPACE/.plugins/nilaway.so"  -buildmode=plugin -trimpath plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint."

--- a/local_build.sh
+++ b/local_build.sh
@@ -2,34 +2,7 @@
 
 set -euo pipefail
 
-YELLOW=$'\e[0;33m'
-NC=$'\e[0m'
+echo "DEPRECATED - use instead:"
+echo "  ./build.sh local"
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd "$SCRIPT_DIR"
-
-output=$(go version -m "$(which golangci-lint)")
-GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
-GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
-tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-
-local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-if [[ "$local_go_version" != "$go_version" ]]; then
-  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}"
-  echo -e "continuing build like normal ..."
-fi
-
-[[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*
-
-set -x
-go mod init github.com/nilaway-plugin
-go mod tidy
-go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
-go mod tidy
-
-GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go
-set +x
-
-echo "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
-  "and make sure to copy the custom settings to your .golangci.yml file."
+exit 1

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -euo pipefail
+
+YELLOW=$'\e[0;33m'
+NC=$'\e[0m'
+
 output=$(go version -m "$(which golangci-lint)")
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
@@ -7,11 +12,9 @@ tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[
 go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-if [[ "$local_go_version" != "$go_version" ]]; then
-  echo -e "FYI - the go version being used right now ($local_go_version) is not the same" \
-    "as the one that was used to build your golangci-lint ($go_version)"
-  echo -e "continuing the build like normal ..."
-fi
+[[ "$local_go_version" != "$go_version" ]] && \
+  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}" &&
+  echo -e "${YELLOW}continuing build like normal ...${NC}"
 
 echo "$tools_version"
 go mod init github.com/nilaway-plugin

--- a/local_build.sh
+++ b/local_build.sh
@@ -6,13 +6,20 @@ GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
+local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [[ "$local_go_version" != "$go_version" ]]; then
+  echo -e "FYI - the go version being used right now ($local_go_version) is not the same" \
+    "as the one that was used to build your golangci-lint ($go_version)"
+  echo -e "continuing the build like normal ..."
+fi
+
 echo "$tools_version"
 go mod init github.com/nilaway-plugin
 go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-echo building nilaway.so with GOARCH="$GOARCH" GOOS="$GOOS" tools_version="$tools_version" go_version="$go_version" ...
+echo building nilaway.so with GOARCH="$GOARCH" GOOS="$GOOS" tools_version="$tools_version" local_go_version="$local_go_version" ...
 GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && \
   echo -e "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
     "and make sure to copy the custom settings to your .golangci.yml file."

--- a/local_build.sh
+++ b/local_build.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 YELLOW=$'\e[0;33m'
 NC=$'\e[0m'
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"
+
 output=$(go version -m "$(which golangci-lint)")
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
@@ -12,17 +15,21 @@ tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[
 go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-[[ "$local_go_version" != "$go_version" ]] && \
-  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}" &&
-  echo -e "${YELLOW}continuing build like normal ...${NC}"
+if [[ "$local_go_version" != "$go_version" ]]; then
+  echo "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}"
+  echo "continuing build like normal ..."
+fi
 
-echo "$tools_version"
+[[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*
+
+set -x
 go mod init github.com/nilaway-plugin
 go mod tidy
 go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-echo building nilaway.so with GOARCH="$GOARCH" GOOS="$GOOS" tools_version="$tools_version" local_go_version="$local_go_version" ...
-GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && \
-  echo -e "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
-    "and make sure to copy the custom settings to your .golangci.yml file."
+GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go
+set +x
+
+echo "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
+  "and make sure to copy the custom settings to your .golangci.yml file."

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
-output=$(go version -m $(which golangci-lint))
+output=$(go version -m "$(which golangci-lint)")
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
-echo $tools_version
+echo "$tools_version"
 go mod init github.com/nilaway-plugin
 go mod tidy
-go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
+go mod edit -replace golang.org/x/tools=golang.org/x/tools@v"$tools_version"
 go mod tidy
 
-echo building nilaway.so with GOARCH=$GOARCH GOOS=$GOOS tools_version=$tools_version go_version=$go_version ...
-GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file."
+echo building nilaway.so with GOARCH="$GOARCH" GOOS="$GOOS" tools_version="$tools_version" go_version="$go_version" ...
+GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && \
+  echo -e "nilaway.so is built compatible with local golangci-lint, please move it under your project directory" \
+    "and make sure to copy the custom settings to your .golangci.yml file."

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-output=$(go version -m echo $(which golangci-lint))
+output=$(go version -m $(which golangci-lint))
 GOARCH=$(grep -oE 'GOARCH=\S+' <<< "$output" | cut -d '=' -f 2)
 GOOS=$(grep -oE 'GOOS=\S+' <<< "$output" | cut -d '=' -f 2)
 tools_version=$(grep 'golang.org/x/tools' <<< "$output" | grep -oE '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
@@ -13,4 +13,4 @@ go mod edit -replace golang.org/x/tools=golang.org/x/tools@v$tools_version
 go mod tidy
 
 echo building nilaway.so with GOARCH=$GOARCH GOOS=$GOOS tools_version=$tools_version go_version=$go_version ...
-GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -o nilaway.so ./plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file."
+GOARCH=$GOARCH GOOS=$GOOS go build -buildmode=plugin -trimpath -o nilaway.so ./plugin/nilaway.go && echo -e "nilaway.so is built compatiable with local golangci-lint, please move it under your project directory and make sure to copy the custom seetings to your .golangci.yml file."

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-echo "DEPRECATED - use instead:"
-echo "  ./build.sh local"
-
-exit 1

--- a/local_build.sh
+++ b/local_build.sh
@@ -16,8 +16,8 @@ go_version=$(grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' <<< "$output" | grep -oE '[0-9]
 
 local_go_version=$(go version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 if [[ "$local_go_version" != "$go_version" ]]; then
-  echo "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}"
-  echo "continuing build like normal ..."
+  echo -e "${YELLOW}warning: local go version ($local_go_version) != go version used to build $(which golangci-lint) ($go_version)${NC}"
+  echo -e "continuing build like normal ..."
 fi
 
 [[ -f "go.mod" || -f "go.sum" ]] && rm -f go.*


### PR DESCRIPTION
## Background

Both scripts use a lot of the same logic. The change to the scripts is +70, -43, so about 27 lines saved there.

Also, as a user I might want to use `build.sh` to build the plugin for a specific version of golangci-lint on my laptop, so there's a use case for doing so outside of GitHub Actions.

Also, on GitHub Actions someone might want to use a custom golangci-lint that they built and make a plugin for that, so in short there's practical reasons to have 1 script.

## Base is set to #2 which is set to #1. [See that diff here](https://github.com/taimoorgit/nilaway-plugin/compare/ta/suggestions...taimoorgit:nilaway-plugin:ta/one-script)

## [See the rendered README.md here](https://github.com/taimoorgit/nilaway-plugin/blob/ta/one-script/README.md)

## Changelog

Scripts:

* NO CHANGE to arguments - backwards compatible. 
* show deprecated message in local_build.sh
* copy over logic from local_build.sh to build.sh
* add more info in help menu
* if GOOS, GOARCH are unset, then set them (if using a binary version of golangci-lint - use the same GOOS, GOARCH from there. if targeting a specific version/latest - use whatever is in `go env`.)

README:

* add `### build` section.
* explain difference between both scripts further.
* remove duplicate YAML in GitHub actions section since the config file there is the exact same.
* re-indent yaml using 2 spaces